### PR TITLE
add extends

### DIFF
--- a/net.krafting.SemantiK.Lang.English.metainfo.xml
+++ b/net.krafting.SemantiK.Lang.English.metainfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <component type="addon">
   <id>net.krafting.SemantiK.Lang.English</id>
+  <extends>net.krafting.SemantiK</extends>
   <name>SemantiK English Language Pack</name>
   <summary>English language pack for SemantiK</summary>
   <summary xml:lang="fr">Pack de langue anglaise pour SemantiK</summary>


### PR DESCRIPTION
Should fix `As-WARNING **: net.krafting.SemantiK.Lang.English was of type addon but had no extends` warning